### PR TITLE
Bugfix inference reporting pdan

### DIFF
--- a/3104_hoi_hub_T16.ipynb
+++ b/3104_hoi_hub_T16.ipynb
@@ -331,6 +331,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62f921be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with tqdm(val_dataloader, unit='batch') as progressive_loader:\n",
+    "    caption_json_path = modelrunner.infer(progressive_loader)\n",
+    "    print(\"file saved to \", caption_json_path)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "5a6e5012",
    "metadata": {},

--- a/ModelInterfaces.py
+++ b/ModelInterfaces.py
@@ -75,10 +75,11 @@ class IModel:
         """
         raise NotImplementedError("Training Interface Method Not Implemented")
     
-    def infer(self, dataloader: DataLoader) -> str:
+    def infer(self, dataloader: DataLoader, confidence_threshold: float = 0.5) -> str:
         """
             Runs inferences on the provided i3D-extracted videos `dataloader`, generates a JSON report
             in a similar structure like the original TSU JSON files.\n
+            Frames with a classification probability below `confidence_threshold` will be excluded. Default 0.5.\n
             Returns the path at which the report was saved.
         """
         raise NotImplementedError("Inference Interface Method Not Implemented")

--- a/ModelInterfaces.py
+++ b/ModelInterfaces.py
@@ -75,10 +75,11 @@ class IModel:
         """
         raise NotImplementedError("Training Interface Method Not Implemented")
     
-    def infer(self, dataloader: DataLoader):
+    def infer(self, dataloader: DataLoader) -> str:
         """
             Runs inferences on the provided i3D-extracted videos `dataloader`, generates a JSON report
-            in a similar structure like the original TSU JSON files.
+            in a similar structure like the original TSU JSON files.\n
+            Returns the path at which the report was saved.
         """
         raise NotImplementedError("Inference Interface Method Not Implemented")
 

--- a/TSU_PDAN.py
+++ b/TSU_PDAN.py
@@ -35,7 +35,7 @@ class HOI_PDAN(IModel):
         model = model.cuda()
         self.model = model
 
-        self.output_directory = "./PDAN/"
+        self.output_directory = "./data/inference/PDAN/"
         self.epoch = 0
 
     def PDAN_training_parameters(self, lr: float = 0.0002, comp_info: str = "TSU_CS_RGB_PDAN"):
@@ -97,7 +97,7 @@ class HOI_PDAN(IModel):
         from time import time
         from pathlib import Path
         # save to configured output_directory, use epoch time as label
-        filename = Path(self.output_directory, "{0}smarthome_{1}.json".format(int(time())))
+        filename = Path(self.output_directory, "smarthome_{0}.json".format(int(time())))
         with open(filename, mode="w") as logfile:
             json.dump(results, fp=logfile)
 

--- a/TSU_PDAN.py
+++ b/TSU_PDAN.py
@@ -92,9 +92,16 @@ class HOI_PDAN(IModel):
             } \
                 for video_name, values in results.items()
         }
-        # TODO: Change path
-        with open("logga.json", mode="w") as logfile:
+        
+        
+        from time import time
+        from pathlib import Path
+        # save to configured output_directory, use epoch time as label
+        filename = Path(self.output_directory, "{0}smarthome_{1}.json".format(int(time())))
+        with open(filename, mode="w") as logfile:
             json.dump(results, fp=logfile)
+
+        return str(filename.resolve())
 
     def evaluate(self, dataloader: DataLoader):
         full_probs, epoch_loss, mAP_acc = HOI.train.val_step(self.model, 0, dataloader, self.epoch)

--- a/TSU_PDAN.py
+++ b/TSU_PDAN.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.optim as optim
 import torch
 import numpy as np
+import json
 from ModelInterfaces import IModel
 
 # TODO: fix TSU's code being hard-coded to check command line arguments


### PR DESCRIPTION
## This PR addresses the following defects
- missing library import required to generate inference report
  - Added import statement
- no way to identify where the new report was saved
  - changed API to return the path to the generated report
- no function documentation for some functions used during inference
  - added explanation for `__compact_result__` private function
  - added link to stackoverflow article explaining how blocks of captions are detected
- inference report includes low-confidence results causing rapid caption flicker
  - filter out predictions with a confidence below threshold, configured by parameter
 
## These defects are related to the following user stories
- T16-44
- T16-21
- T16-22
- T16-23